### PR TITLE
Act on render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-formik-side-effects",
   "description": "Formik side effects hook and wrapper component",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "release/index.js",
   "umd:main": "release/index.umd.js",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-formik-side-effects",
   "description": "Formik side effects hook and wrapper component",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "main": "release/index.js",
   "umd:main": "release/index.umd.js",
   "source": "src/index.ts",

--- a/src/useFormikSideEffects.ts
+++ b/src/useFormikSideEffects.ts
@@ -53,7 +53,6 @@ export const useFormikSideEffects = <T extends {}>(
   React.useEffect(() => {
     const previousFormik = previous.current;
 
-    if (previousFormik.values !== currentFormik.values) {
       if (determineSideEffect) {
         const sideEffect = determineSideEffect(
           currentFormik.values,
@@ -78,7 +77,6 @@ export const useFormikSideEffects = <T extends {}>(
           abortController.current.signal
         );
       }
-    }
 
     previous.current = currentFormik;
   }, [currentFormik, determineSideEffect, determineAsyncSideEffect]);


### PR DESCRIPTION
To be able to act on render and not only when formik values changes, the condition to execute on  currentvalues != previousvalues, has been removed.